### PR TITLE
improved diag messages

### DIFF
--- a/src/app/components/error-window/error-window.component.html
+++ b/src/app/components/error-window/error-window.component.html
@@ -3,7 +3,10 @@
   <div body class="errorBody">
     <ng-container *ngIf="appError">
       <p class="errorComment">{{appError.comment}}</p>
-      <p class="errorMessage">{{appError.error.message}}</p>
+      <p class="errorMessage">{{appError.error.message
+      || appError.error.params?.error
+      || appError.error.startsWith && appError.error.startsWith('discovery_document_') && "some details may be found in the JS console"}}</p>
+      <p class="errorMessage">{{appError.error.params?.error_description?.replaceAll('+',' ')}}</p>
       <button type="button" mat-raised-button color="primary" (click)="restartApplication()">
           <mat-icon>refresh</mat-icon> Restart
       </button>


### PR DESCRIPTION
Improved diag messages when something failed while fetching&loading&verifying the discovery document.
Some early messages from ng oidc support dump error info to JS console via ng logger, so the user gets any information.
However, later error messages from app's authentication.service.ts end up without any presentation of details.
See screenshots below.

This is quite useful addition for people who just fetch this app & run it as-is, without any IDE, or without actual knowledge where to set a breakpoint to see the actual error message.

Since I covered only a few cases that I've stumbled upon, this is probably nowhere near a full presentation of all possible messages though. Also, it might actually be more reasonable to just JSON.stringify the error object instead of extracting the messages, but still should be handy as-is sent in this PR with no work added.